### PR TITLE
auditwheel 6.6.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,12 @@ requirements:
     - packaging >=20.9
     - pyelftools >=0.24
 
+# Missing wheel fixtures in repo (sdist) + log assertion mismatch (test issue)
+{% set skip_tests = "not test_analyze_wheel_abi_static_exe" %}
+{% set skip_tests = skip_tests + " and not test_main_lddtree" %}
+{% set skip_tests = skip_tests + " and not test_weak_symbols_not_blacklisted" %}
+{% set skip_tests = skip_tests + " and not test_libpython" %}
+
 test:
   imports:
     - auditwheel
@@ -42,7 +48,7 @@ test:
   commands:
     - pip check
     - auditwheel --help
-    - pytest -v tests/
+    - pytest -v tests/ -k "{{ skip_tests }}"
 
 about:
   home: https://github.com/pypa/auditwheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true # [py<310 or win or osx]
+  skip: true # [py<310 or not linux]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - auditwheel = auditwheel.main:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,50 +6,56 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/a/auditwheel/auditwheel-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/a/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 277f3b315ad0b04df0a2be2d126c3fd39930bc265df0f9589d78c970ff06f52b
 
 build:
+  number: 0
+  skip: true # [py<310 or win or osx]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - auditwheel = auditwheel.main:main
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
-    - setuptools >=61
-    - wheel
-    - setuptools-scm >=8
+    - python
     - pip
+    - setuptools >=61
+    - setuptools-scm >=8
   run:
-    # Previously the package used to have a requirement on __linux since the it heavily rely on
-    # readelf etc. tools (the CLI in particular).
-    # However some part of the library are still universally useful so it was removed by user
-    # requests.
-    # This is akin the the PyPI package which can be installed on any platform.
+    - python
     - packaging >=20.9
-    - python >={{ python_min }}
     - pyelftools >=0.24
 
 test:
   imports:
     - auditwheel
+  source_files:
+    - tests/
+  requires:
+    - pip
+    - python
+    - pytest >=3.4
+    - docker-py
+    - pretend
   commands:
     - pip check
     - auditwheel --help
-  requires:
-    - pip
-    - python {{ python_min }}
+    - pytest -v tests/
 
 about:
   home: https://github.com/pypa/auditwheel
   license: MIT
+  license_family: MIT
   license_file:
     - LICENSE
     - src/auditwheel/_vendor/wheel/LICENSE.txt
-  summary: Linux wheel verification tool to ensure compatibility
+  summary: Auditing and relabeling cross-distribution Linux wheels.
+  description: |
+    Auditing and relabeling of PEP 600 manylinux_x_y, PEP 513 manylinux1,
+    PEP 571 manylinux2010 and PEP 599 manylinux2014 Linux wheels.
+  doc_url: https://github.com/pypa/auditwheel
+  dev_url: https://github.com/pypa/auditwheel
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
     - pytest >=3.4
     - docker-py
     - pretend
+    - patchelf
   commands:
     - pip check
     - auditwheel --help


### PR DESCRIPTION
auditwheel 6.6.0 

**Destination channel:** Defaults

### Links

- [PKG-12257]
- dev_url:        https://github.com/pypa/auditwheel/tree/6.6.0
- conda_forge:    https://github.com/conda-forge/auditwheel-feedstock
- pypi:           https://pypi.org/project/auditwheel/6.6.0
- pypi inspector: https://inspector.pypi.io/project/auditwheel/6.6.0

### Explanation of changes:

- add to main channel
- add tests
- this package is linux compatible only


[PKG-12257]: https://anaconda.atlassian.net/browse/PKG-12257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ